### PR TITLE
Improved TDKLambdaZPlus support

### DIFF
--- a/scpi/devices/generic.py
+++ b/scpi/devices/generic.py
@@ -37,9 +37,6 @@ class PowerSupply(SCPIDevice):
     async def set_voltage(self, millivolts, extra_params=""):
         """Sets the desired output voltage (but does not auto-enable outputs) in millivolts,
         pass extra_params string to append to the command (like ":PROT")"""
-        # TODO: for debugging, limit voltage to 5V
-        if millivolts > 5000:
-            millivolts = 5000
         await self.command("SOUR:VOLT%s %f MV" % (extra_params, millivolts))
 
     async def query_voltage(self, extra_params=""):
@@ -51,9 +48,6 @@ class PowerSupply(SCPIDevice):
     async def set_current(self, milliamps, extra_params=""):
         """Sets the desired output current (but does not auto-enable outputs) in milliamps,
         pass extra_params string to append to the command (like ":TRIG")"""
-        # TODO: for debugging, limit current to 0.12A
-        if milliamps > 120:
-            milliamps = 120
         await self.command("SOUR:CURR%s %f MA" % (extra_params, milliamps))
 
     async def query_current(self, extra_params=""):

--- a/scpi/scpi.py
+++ b/scpi/scpi.py
@@ -324,3 +324,39 @@ class SCPIDevice(object):
         Sends an Operation Complete command.
         """
         await self.command("*OPC")
+
+    async def query_options(self):
+        """
+        Queries the model's options.
+        """
+        await self.ask("*OPT?")
+
+    async def set_power_on_status_clear(self, setting):
+        """
+        Set the Power-On Status Clear setting.
+        """
+        await self.command("*PSC %s" % setting)
+
+    async def save_state(self, state):
+        """
+        The SAV command saves all applied configuration settings.
+        """
+        state = int(state)
+        assert state in (1, 2, 3, 4)
+
+        await self.command("*SAV %d" % state)
+
+    async def restore_state(self, state):
+        """
+        Restores the power supply to a state previously stored in memory by *SAV command.
+        """
+        state = int(state)
+
+        await self.command("*RCL %d" % state)
+
+    async def power_on_state(self, setting):
+        """
+        Set the power-on behavior of the system
+        """
+        setting = str(setting).upper()
+        await self.command("*OUTP:PON %s" % setting)


### PR DESCRIPTION
This pull request adds some compatibility for commands used by the TDKLambdaZPlus.  

- Adds several generic commands to the scpi.SCPIDevice class
- Adds the TDKLambdaZPlus.TDKSCPI(SCPIDevice) class, which does value checking for TDK flavored syntax.
- Modifies the TDKLambdaZPlus.TDKLambdaZplus(PowerSupply, TDKSCPI) class to inherit the proper commands, and adds some to measure and set values with hardware limits. 
- Adds the TDKLambdaZPlus.serial method for quickly connecting to an instrument over a serial port (RS232 or USB COM)