### PR TITLE
transports:tcp: Remove loop parameter from open_connection

### DIFF
--- a/src/scpi/transports/tcp.py
+++ b/src/scpi/transports/tcp.py
@@ -22,7 +22,7 @@ class TCPTransport(BaseTransport):
 
     async def open_connection(self, ipaddr: str, port: int) -> None:
         """Open a connection (also update the IP/port)"""
-        self.reader, self.writer = await asyncio.open_connection(ipaddr, port, loop=asyncio.get_event_loop())
+        self.reader, self.writer = await asyncio.open_connection(ipaddr, port)
         self.ipaddr = ipaddr
         self.port = port
 


### PR DESCRIPTION
TypeError: BaseEventLoop.create_connection() got an unexpected keyword argument 'loop'

The loop parameter in open_connection has been removed in Python 3.10. It's now passed on to BaseEventLoop.create_connection() which gives the above error.